### PR TITLE
Adding support for pending events

### DIFF
--- a/include-churchsuite-events.php
+++ b/include-churchsuite-events.php
@@ -195,6 +195,8 @@ function cs_events_shortcode($atts = [])
 
             if ($event->status == 'cancelled') {
                 $output .= '<span style="text-decoration:line-through">';
+            } else if ($event->status == 'pending') {
+                $output .= '<span style="font-style: italic">';
             }
 
             if ($link_titles == true) {
@@ -222,6 +224,8 @@ function cs_events_shortcode($atts = [])
 
             if ($event->status == 'cancelled') {
                 $output .= '</span>';
+            } else if ($event->status == 'pending') {
+                $output .= '?</span>';
             }
 
             $output .= '</h4>';


### PR DESCRIPTION
In addition to Cancelled and Confirmed events, ChurchSuite also supports the Pending status. This PR adds support for the "pending" status, including styling it in the same way as it would be within ChurchSuite, namely italicised and with a trailing question mark to indicate the pending nature.