### PR TITLE
Add exclude_categories parameter

### DIFF
--- a/include-churchsuite-events.php
+++ b/include-churchsuite-events.php
@@ -3,7 +3,7 @@
 Plugin Name: Include ChurchSuite Events
 Plugin URI: https://github.com/whitkirkchurch/include-churchsuite-events
 Description: Gets a list of events from a ChurchSuite account, and includes it as part of a post or page.
-Version: 1.2.2
+Version: 1.3.0
 Author: St Mary's Church, Whitkirk
 Author URI: https://whitkirkchurch.org.uk
 License:     GPL-2.0+
@@ -80,6 +80,13 @@ function cs_events_shortcode($atts = [])
         $limit_to_count = true;
     }
 
+    if (isset($atts['exclude_categories'])) {
+        $exclude_categories = explode(',', $atts['exclude_categories']);
+        unset($atts['exclude_categories']);
+    } else {
+        $exclude_categories = [];
+    }
+
     try {
         $params = [];
 
@@ -105,6 +112,12 @@ function cs_events_shortcode($atts = [])
 
         // This is where most of the magic happens
         foreach ($data_to_loop as $event) {
+
+            // If the event's category is in the exclude list, just skip the loop for it
+            if (in_array($event->category->id, $exclude_categories)) {
+                continue;
+            }
+            
             // Build the event URL, we use this a couple of times
             $event_url =
                 'https://' .

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: jacksonj04
 Tags: churchsuite, events
 Requires at least: 4.7
-Tested up to: 5.4.1
-Stable tag: v1.2.2
+Tested up to: 6.0.1
+Stable tag: v1.3.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Donate link: https://whitkirkchurch.org.uk/donate
@@ -43,6 +43,7 @@ There are some additional parameters you can pass:
 * `show_end_times`: Display the time an event is scheduled to end. Defaults to false.
 * `show_locations`: Display details of an event's location. Defaults to false.
 * `show_descriptions`: Display and event's description if given. Defaults to true.
+* `exclude_categories`: A comma-delimited list of category IDs to exclude from the output. Defaults to an empty array.
 
 == Changelog ==
 
@@ -74,3 +75,7 @@ There are some additional parameters you can pass:
 = 1.2.2 =
 
 * Updated "missing site parameter" error message, to "missing account parameter"
+
+= 1.3.0 =
+
+* Added `exclude_categories` parameter.


### PR DESCRIPTION
Pass a comma-delimited list of category IDs to exclude from the output as the `exclude_categories` parameter.