### PR TITLE
Add flag for disabling image display

### DIFF
--- a/include-churchsuite-events.php
+++ b/include-churchsuite-events.php
@@ -73,6 +73,13 @@ function cs_events_shortcode($atts = [])
         $show_descriptions = true;
     }
 
+    if (isset($atts['show_images'])) {
+        $show_images = (bool) $atts['show_images'];
+        unset($atts['show_images']);
+    } else {
+        $show_images = true;
+    }
+
     if (isset($atts['limit_to_count'])) {
         $limit_to_count = (int) $atts['limit_to_count'];
         unset($atts['limit_to_count']);
@@ -211,7 +218,7 @@ function cs_events_shortcode($atts = [])
 
             $output .= '<div class="cs_events--event">';
 
-            if (isset($event->images->thumb) && $event->description != '') {
+            if ($show_images && isset($event->images->thumb) && $event->description != '') {
                 if ($link_titles == true) {
                     $output .=
                         '<a href="https://' .

--- a/readme.txt
+++ b/readme.txt
@@ -42,7 +42,8 @@ There are some additional parameters you can pass:
 * `show_years`: If set to `always`, will always show the year in each date. If set to `different`, will only show years in dates where they are not the current year. Defaults to false.
 * `show_end_times`: Display the time an event is scheduled to end. Defaults to false.
 * `show_locations`: Display details of an event's location. Defaults to false.
-* `show_descriptions`: Display and event's description if given. Defaults to true.
+* `show_descriptions`: Display an event's description if present. Defaults to true.
+* `show_images`: Display an event's image if present. Defaults to true.
 * `exclude_categories`: A comma-delimited list of category IDs to exclude from the output. Defaults to an empty array.
 
 == Changelog ==
@@ -79,3 +80,7 @@ There are some additional parameters you can pass:
 = 1.3.0 =
 
 * Added `exclude_categories` parameter.
+
+= Unreleased =
+
+* Added `display_images` parameter.


### PR DESCRIPTION
In some cases (eg where a sequence of events all share the same image) we may want to disable the display of images in a list. This adds the option to do so.